### PR TITLE
update is_atom function to follow PEP8

### DIFF
--- a/diylisp/ast.py
+++ b/diylisp/ast.py
@@ -29,7 +29,7 @@ def is_closure(x):
 
 
 def is_atom(x):
-    return is_symbol(x) \
-        or is_integer(x) \
-        or is_boolean(x) \
-        or is_closure(x)
+    return (is_symbol(x) or
+    	is_integer(x) or
+    	is_boolean(x) or
+    	is_closure(x))


### PR DESCRIPTION
- "The preferred way of wrapping long lines is by using Python's implied line continuation inside parentheses, brackets and braces. Long lines can be broken over multiple lines by wrapping expressions in parentheses. These should be used in preference to using a backslash for line continuation."
- "The preferred place to break around a binary operator is after the operator, not before it."

[Source](http://legacy.python.org/dev/peps/pep-0008/#maximum-line-length)
